### PR TITLE
Handle both url_to_doc, urlToDoc

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,12 +95,20 @@ function parseCorpus(corpusSpec, indexPath, corpus) {
       Object.keys(rawJson).forEach(function(key) {
         corpusSpec[key] = rawJson[key];
       });
+      adjustCorpusSpecProperties(corpusSpec);
       corpusSpec.eventEmitter.emit('refreshed');
       resolve();
     } catch (err) {
       reject(new Error('failed to parse ' + indexPath + ': ' + err));
     }
   });
+}
+
+function adjustCorpusSpecProperties(corpusSpec) {
+  if (corpusSpec.url_to_doc) {
+    corpusSpec.urlToDoc = corpusSpec.url_to_doc;
+    delete corpusSpec.url_to_doc;
+  }
 }
 
 function launchServer(lunrServer, resolve, reject) {
@@ -136,8 +144,7 @@ function handleRequest(lunrServer, req, res) {
         corpusResults = corpusSpec.index.search(queryParams);
 
     corpusResults = corpusResults.map(function(result) {
-      var urlToDoc = (corpusSpec.url_to_doc || corpusSpec.urlToDoc),
-          urlAndTitle = urlToDoc[result.ref];
+      var urlAndTitle = corpusSpec.urlToDoc[result.ref];
       Object.keys(urlAndTitle).forEach(function(key) {
         result[key] = urlAndTitle[key];
       });

--- a/index.js
+++ b/index.js
@@ -30,11 +30,9 @@ LunrServer.prototype.prepare = function() {
 
   this.watchers = this.corpora.map(function(corpusSpec) {
     // reload an index when child corpus changes it
-    return fs.watch(
-      corpusSpec['indexPath'],
-      (event, filename) => {
-        loadIndex(lunrServer, corpusSpec);
-      });
+    return fs.watch(corpusSpec['indexPath'], () => {
+      loadIndex(lunrServer, corpusSpec);
+    });
   });
 
   return Promise.all(this.corpora.map(function(corpusSpec) {
@@ -46,9 +44,9 @@ LunrServer.prototype.prepare = function() {
 LunrServer.prototype.launch = function() {
   var lunrServer = this;
 
-  this.prepare().then(function() {
+  return this.prepare().then(function() {
     return new Promise(function(resolve, reject) {
-      launchServer(lunrServer, reject);
+      launchServer(lunrServer, resolve, reject);
     });
   });
 };
@@ -105,7 +103,7 @@ function parseCorpus(corpusSpec, indexPath, corpus) {
   });
 }
 
-function launchServer(lunrServer, reject) {
+function launchServer(lunrServer, resolve, reject) {
   lunrServer.httpServer = new http.Server(function(req, res) {
     handleRequest(lunrServer, req, res);
   });
@@ -114,9 +112,10 @@ function launchServer(lunrServer, reject) {
     reject(err);
   });
 
-  lunrServer.logger.log(
-    packageInfo.name + ': listening on port', lunrServer.port);
   lunrServer.httpServer.listen(lunrServer.port);
+  lunrServer.logger.log(packageInfo.name + ': listening on',
+    lunrServer.httpServer.address().port);
+  resolve();
 }
 
 function handleRequest(lunrServer, req, res) {
@@ -137,7 +136,8 @@ function handleRequest(lunrServer, req, res) {
         corpusResults = corpusSpec.index.search(queryParams);
 
     corpusResults = corpusResults.map(function(result) {
-      var urlAndTitle = corpusSpec.url_to_doc[result.ref];
+      var urlToDoc = (corpusSpec.url_to_doc || corpusSpec.urlToDoc),
+          urlAndTitle = urlToDoc[result.ref];
       Object.keys(urlAndTitle).forEach(function(key) {
         result[key] = urlAndTitle[key];
       });

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "gulp-eslint": "^1.1.1",
     "gulp-mocha": "^2.2.0",
     "mocha": "^2.3.4",
-    "simple-node-logger": "^1.0"
+    "temp": "^0.8.3"
   }
 }

--- a/test/corpus-format-test.js
+++ b/test/corpus-format-test.js
@@ -1,0 +1,127 @@
+'use strict';
+
+var LunrServer = require('../index');
+var fs = require('fs');
+var http = require('http');
+var lunr = require('lunr');
+var temp = require('temp');
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('Corpus format', function() {
+  var lunrServer,
+      config,
+      indexPath,
+      writeIndexAndMakeRequest;
+
+  afterEach(function() {
+    return lunrServer.close().then(function() {
+      if (!indexPath) {
+        return;
+      }
+      return new Promise(function(resolve, reject) {
+        fs.unlink(indexPath, function(err) {
+          err ? reject(err) : resolve();
+        });
+      });
+    });
+  });
+
+  it('should handle url_to_doc', function() {
+    return writeIndexAndMakeRequest(createIndex())
+      .then(function(response) {
+        response.statusCode.should.eql(200);
+      });
+  });
+
+  it('should handle urlToDoc', function() {
+    var index = createIndex();
+    index.urlToDoc = index.url_to_doc;
+    delete index.url_to_doc;
+
+    return writeIndexAndMakeRequest(index)
+      .then(function(response) {
+        response.statusCode.should.eql(200);
+      });
+  });
+
+  writeIndexAndMakeRequest = function(index) {
+    return writeIndex(index)
+      .then(function(newIndexPath) {
+        indexPath = newIndexPath;
+        config = createConfig();
+        config.corpora[0].indexPath = indexPath;
+        lunrServer = new LunrServer(config, console);
+        return lunrServer.launch();
+      })
+      .then(function() {
+        return makeRequest(lunrServer, 'foobar');
+      });
+  };
+});
+
+function createIndex() {
+  var index = lunr(function() {
+    this.ref('url');
+    this.field('url', 10);
+    this.field('title', 10);
+    this.field('body', 0);
+  });
+
+  index.add({
+    url: '/foobar/',
+    title: 'Foobar',
+    body: 'foobar bazquux'
+  });
+
+  return {
+    index: index.toJSON(),
+    url_to_doc: {  // eslint-disable-line camelcase
+      '/foobar/': { url: '/foobar/', title: 'Foobar'}
+    }
+  };
+}
+
+function writeIndex(index) {
+  return new Promise(function(resolve, reject) {
+    temp.open('corpus-format-test-', function(err, info) {
+      if (err) {
+        return reject(err);
+      }
+      fs.write(info.fd, JSON.stringify(index));
+      fs.close(info.fd, function(err) {
+        err ? reject(err) : resolve(info.path);
+      });
+    });
+  });
+}
+
+function createConfig() {
+  return {
+    'corpora': [
+      {
+        'name': 'Test Index',
+        'baseurl': 'https://18f.gsa.gov'
+      }
+    ],
+    'port': 0
+  };
+}
+
+function makeRequest(lunrServer, query) {
+  var options = {
+    protocol: 'http:',
+    hostname: 'localhost',
+    port: lunrServer.httpServer.address().port,
+    path: '/?q=' + query,
+    method: 'GET'
+  };
+  return new Promise(function(resolve) {
+    http.request(options, function(res) {
+      resolve(res);
+    }).end();
+  });
+}

--- a/test/watch-corpus-indexes-test.js
+++ b/test/watch-corpus-indexes-test.js
@@ -1,22 +1,23 @@
 'use strict';
 
-var fs = require('fs');
 var LunrServer = require('../index');
+var fs = require('fs');
+var path = require('path');
 var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
 
 chai.should();
 chai.use(chaiAsPromised);
 
-describe ('TestHarness', function() {
+describe ('Watch corpus indexes', function() {
   var config = {
         'corpora': [
       { 'name': 'Test Index',
         'baseurl': 'https://18f.gsa.gov',
-        'indexPath': './test/indexes/search-index.json'
+        'indexPath': path.join('./test/indexes/search-index.json')
       }
         ],
-        'port': 8080
+        'port': 0
       },
       lunrServer,
       corpus;
@@ -24,7 +25,7 @@ describe ('TestHarness', function() {
   before(function() {
     lunrServer = new LunrServer(config);
     fs.createReadStream(
-      './test/indexes/search-index-one-short-page.json'
+      path.join('./test/indexes/search-index-one-short-page.json')
     ).pipe(fs.createWriteStream(config.corpora[0].indexPath));
   });
 
@@ -49,7 +50,7 @@ describe ('TestHarness', function() {
 
             // Now add page 2 to the index
             fs.createReadStream(
-              './test/indexes/search-index-two-short-pages.json'
+              path.join('./test/indexes/search-index-two-short-pages.json')
             ).pipe(fs.createWriteStream(config.corpora[0].indexPath));
 
             // This promise will be fulfilled only when


### PR DESCRIPTION
This field name changed in jekyll_pages_api_search#16, release in v0.4.0. Consequently, the lunr-server would try to read from an undefined field name and crash.

We probably need more graceful error handling in general, and some of this test harness code could probably be extracted into a test utility used between tests, but let's save that for a future PR.

cc: @catherinedevlin @jbarnicle 
